### PR TITLE
Allow earlier memberships

### DIFF
--- a/lib/membership_comparison/start_comparison.rb
+++ b/lib/membership_comparison/start_comparison.rb
@@ -10,10 +10,18 @@ class MembershipComparison
       super || ended?
     end
 
+    def partial?
+      super && started_before_term_ended?
+    end
+
     private
 
     def ended?
       statement_end && statement_start < statement_end
+    end
+
+    def started_before_term_ended?
+      !statement_start || !suggestion_term_end || statement_start <= suggestion_term_end
     end
 
     def statement_start
@@ -26,6 +34,10 @@ class MembershipComparison
 
     def suggestion_term_start
       suggestion.dig(:term, :start)
+    end
+
+    def suggestion_term_end
+      suggestion.dig(:term, :end)
     end
   end
 end

--- a/lib/membership_comparison/start_comparison.rb
+++ b/lib/membership_comparison/start_comparison.rb
@@ -7,21 +7,57 @@ class MembershipComparison
     self.field = :start
 
     def conflict?
-      super || ended?
+      suggestion_started_during_statement? &&
+        (suggestion_open? || suggestion_ended_after_statement?)
     end
 
     def partial?
-      super && started_before_term_ended?
+      suggestion_started_during_statement? ||
+        (suggestion_open? && suggestion_started_after_statement?)
     end
 
     private
 
-    def ended?
-      statement_end && statement_start < statement_end
+    def suggestion_started_during_statement?
+      return false unless statement_closed? && suggestion_started?
+
+      statement_start <= suggestion_start && suggestion_start < statement_end
     end
 
-    def started_before_term_ended?
-      !statement_start || !suggestion_term_end || statement_start <= suggestion_term_end
+    def suggestion_ended_after_statement?
+      return false unless statement_closed? && suggestion_closed?
+
+      statement_end < suggestion_end
+    end
+
+    def suggestion_started_after_statement?
+      return false unless statement_started? && suggestion_started?
+
+      statement_start <= suggestion_start
+    end
+
+    def statement_started?
+      statement_start
+    end
+
+    def statement_closed?
+      statement_started? && statement_end
+    end
+
+    def statement_open?
+      !statement_closed?
+    end
+
+    def suggestion_started?
+      suggestion_start
+    end
+
+    def suggestion_closed?
+      suggestion_started? && suggestion_end
+    end
+
+    def suggestion_open?
+      !suggestion_closed?
     end
 
     def statement_start
@@ -32,11 +68,11 @@ class MembershipComparison
       statement[:end]
     end
 
-    def suggestion_term_start
+    def suggestion_start
       suggestion.dig(:term, :start)
     end
 
-    def suggestion_term_end
+    def suggestion_end
       suggestion.dig(:term, :end)
     end
   end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -243,4 +243,40 @@ describe MembershipComparison do
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to be_empty }
   end
+
+  context 'existing P39s, surrounding and including terms' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-0040' => { position: mp, term: term40, party: liberal, district: pontiac },
+          'wds:1030-1DAA-0041' => { position: mp, term: term41, party: liberal, district: pontiac },
+          'wds:1030-1DAA-0042' => { position: mp, term: term42, party: liberal, district: pontiac },
+        },
+        suggestion: suggestion41
+      )
+    end
+
+    specify { expect(comparison.exact_matches).to match_array(['wds:1030-1DAA-0041']) }
+    specify { expect(comparison.partial_matches).to be_empty }
+    specify { expect(comparison.conflicts).to be_empty }
+  end
+
+  context 'existing P39s, surrounding and including dates' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-1040' => { position: mp, start: '2008-11-18', end: '2011-03-26', party: liberal,
+                                    district: pontiac, },
+          'wds:1030-1DAA-1041' => { position: mp, start: '2011-06-02', end: '2015-08-02', party: liberal,
+                                    district: pontiac, },
+          'wds:1030-1DAA-1042' => { position: mp, start: '2017-01-03', party: liberal, district: pontiac },
+        },
+        suggestion: suggestion41
+      )
+    end
+
+    specify { expect(comparison.exact_matches).to be_empty }
+    specify { expect(comparison.partial_matches).to match_array(['wds:1030-1DAA-1041']) }
+    specify { expect(comparison.conflicts).to be_empty }
+  end
 end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -194,4 +194,19 @@ describe MembershipComparison do
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3105']) }
   end
+
+  context 'existing dated P39, later term' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-3103' => { position: mp, start: '2015-12-03', party: liberal, district: pontiac },
+        },
+        suggestion: suggestion41
+      )
+    end
+
+    specify { expect(comparison.exact_matches).to be_empty }
+    specify { expect(comparison.partial_matches).to be_empty }
+    specify { expect(comparison.conflicts).to be_empty }
+  end
 end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -9,6 +9,7 @@ describe MembershipComparison do
   let(:liberal) { { id: 'Q138345' } }
   let(:conservative) { { id: 'Q488523' } }
   let(:pontiac) { { id: 'Q3397734' } }
+  let(:term40) { { id: 'Q2816776', start: '2008-11-18', end: '2011-03-26' } }
   let(:term41) { { id: 'Q2816776', start: '2011-06-02', end: '2015-08-02' } }
   let(:term42) { { id: 'Q21157957', start: '2015-12-03' } }
   let(:suggestion) { { position: mp, term: term42, party: liberal, district: pontiac } }
@@ -200,6 +201,39 @@ describe MembershipComparison do
       MembershipComparison.new(
         existing:   {
           'wds:1030-1DAA-3103' => { position: mp, start: '2015-12-03', party: liberal, district: pontiac },
+        },
+        suggestion: suggestion41
+      )
+    end
+
+    specify { expect(comparison.exact_matches).to be_empty }
+    specify { expect(comparison.partial_matches).to be_empty }
+    specify { expect(comparison.conflicts).to be_empty }
+  end
+
+  context 'existing P39s, surrounding terms' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-3140' => { position: mp, term: term40, party: liberal, district: pontiac },
+          'wds:1030-1DAA-3101' => { position: mp, term: term42, party: liberal, district: pontiac },
+        },
+        suggestion: suggestion41
+      )
+    end
+
+    specify { expect(comparison.exact_matches).to be_empty }
+    specify { expect(comparison.partial_matches).to be_empty }
+    specify { expect(comparison.conflicts).to be_empty }
+  end
+
+  context 'existing P39s, surrounding dates' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-3140' => { position: mp, start: '2008-11-18', end: '2011-03-26', party: liberal,
+                                    district: pontiac, },
+          'wds:1030-1DAA-3101' => { position: mp, start: '2017-01-03', party: liberal, district: pontiac },
         },
         suggestion: suggestion41
       )


### PR DESCRIPTION
Given an existing date-only membership entirely within the 42nd Term, a
suggestion for the 41st term should be createable.