### PR TITLE
Allow a member to return within the same term

### DIFF
--- a/lib/membership_comparison/start_comparison.rb
+++ b/lib/membership_comparison/start_comparison.rb
@@ -7,33 +7,33 @@ class MembershipComparison
     self.field = :start
 
     def conflict?
-      suggestion_started_during_statement? &&
-        (suggestion_open? || suggestion_ended_after_statement?)
+      term_started_during_statement? &&
+        (term_open? || term_ended_after_statement?)
     end
 
     def partial?
-      suggestion_started_during_statement? ||
-        (suggestion_open? && suggestion_started_after_statement?)
+      term_started_during_statement? ||
+        (term_open? && term_started_after_statement?)
     end
 
     private
 
-    def suggestion_started_during_statement?
-      return false unless statement_closed? && suggestion_started?
+    def term_started_during_statement?
+      return false unless statement_closed? && term_started?
 
-      statement_start <= suggestion_start && suggestion_start < statement_end
+      statement_start <= term_start && term_start < statement_end
     end
 
-    def suggestion_ended_after_statement?
-      return false unless statement_closed? && suggestion_closed?
+    def term_ended_after_statement?
+      return false unless statement_closed? && term_closed?
 
-      statement_end < suggestion_end
+      statement_end < term_end
     end
 
-    def suggestion_started_after_statement?
-      return false unless statement_started? && suggestion_started?
+    def term_started_after_statement?
+      return false unless statement_started? && term_started?
 
-      statement_start <= suggestion_start
+      statement_start <= term_start
     end
 
     def statement_started?
@@ -48,16 +48,16 @@ class MembershipComparison
       !statement_closed?
     end
 
-    def suggestion_started?
-      suggestion_start
+    def term_started?
+      term_start
     end
 
-    def suggestion_closed?
-      suggestion_started? && suggestion_end
+    def term_closed?
+      term_started? && term_end
     end
 
-    def suggestion_open?
-      !suggestion_closed?
+    def term_open?
+      !term_closed?
     end
 
     def statement_start
@@ -68,11 +68,11 @@ class MembershipComparison
       statement[:end]
     end
 
-    def suggestion_start
+    def term_start
       suggestion.dig(:term, :start)
     end
 
-    def suggestion_end
+    def term_end
       suggestion.dig(:term, :end)
     end
   end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -329,7 +329,7 @@ describe MembershipComparison do
 
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
-    specify { expect(comparison.conflicts).to be_empty } # Currently fails
+    specify { expect(comparison.conflicts).to be_empty }
   end
 
   context 'member returns within term (previous still open)' do
@@ -346,7 +346,7 @@ describe MembershipComparison do
     # Term:                  2015-12-03 --------------->
     # Suggestion:                          2017-01-03 ->
 
-    specify { expect(comparison.exact_matches).to be_empty } # Currently fails
+    specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3107']) }
   end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -295,4 +295,19 @@ describe MembershipComparison do
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to be_empty } # Currently fails
   end
+
+  context 'member returns within term (previous still open)' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-3107' => { position: mp, start: '2015-12-03', party: liberal, district: pontiac },
+        },
+        suggestion: { position: mp, term: term42, start: '2017-01-03', party: liberal, district: pontiac }
+      )
+    end
+
+    specify { expect(comparison.exact_matches).to be_empty } # Currently fails
+    specify { expect(comparison.partial_matches).to be_empty }
+    specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3107']) }
+  end
 end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -15,6 +15,14 @@ describe MembershipComparison do
   let(:suggestion) { { position: mp, term: term42, party: liberal, district: pontiac } }
   let(:suggestion41) { { position: mp, term: term41, party: liberal, district: pontiac } }
 
+  after do |ex|
+    next unless ex.display_exception
+
+    puts
+    puts "statements: #{comparison.send(:existing).values}"
+    puts "suggestion: #{comparison.send(:suggestion)}"
+  end
+
   context 'no existing P39s' do
     let(:comparison) do
       MembershipComparison.new(
@@ -160,6 +168,9 @@ describe MembershipComparison do
       )
     end
 
+    # Statements: 2015-12-03 ->
+    # Term:       2015-12-03 ->
+
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to match_array(['wds:1030-1DAA-3103']) }
     specify { expect(comparison.conflicts).to be_empty }
@@ -174,6 +185,9 @@ describe MembershipComparison do
         suggestion: suggestion
       )
     end
+
+    # Statements: 2015-10-18 ------------>
+    # Term:                  2015-12-03 ->
 
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to match_array(['wds:1030-1DAA-3104']) }
@@ -191,6 +205,9 @@ describe MembershipComparison do
       )
     end
 
+    # Statements: 2011-06-02 ------------> 2017-11-12
+    # Term:                  2015-12-03 ->
+
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3105']) }
@@ -205,6 +222,9 @@ describe MembershipComparison do
         suggestion: suggestion41
       )
     end
+
+    # Statements:            2015-12-03 ->
+    # Term:       2011-06-02 ------------>
 
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
@@ -221,6 +241,9 @@ describe MembershipComparison do
         suggestion: suggestion41
       )
     end
+
+    # Statements: 2008-11-18 -> 2011-03-26 |                          | 2015-12-03 ->
+    # Term:                                | 2011-06-02 -> 2015-08-02 |
 
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
@@ -239,6 +262,9 @@ describe MembershipComparison do
       )
     end
 
+    # Statements: 2008-11-18 -> 2011-03-26 |                          | 2017-01-03 ->
+    # Term:                                | 2011-03-26 -> 2015-08-02 |
+
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to be_empty }
@@ -255,6 +281,9 @@ describe MembershipComparison do
         suggestion: suggestion41
       )
     end
+
+    # Statements: 2008-11-18 -> 2011-03-26 | 2011-06-02 -> 2015-08-02 | 2015-12-03 ->
+    # Term:                                | 2011-06-02 -> 2015-08-02 |
 
     specify { expect(comparison.exact_matches).to match_array(['wds:1030-1DAA-0041']) }
     specify { expect(comparison.partial_matches).to be_empty }
@@ -275,6 +304,9 @@ describe MembershipComparison do
       )
     end
 
+    # Statements: 2008-11-18 -> 2011-03-26 | 2011-06-02 -> 2015-08-02 | 2017-01-03 ->
+    # Term:                                | 2011-06-02 -> 2015-08-02 |
+
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to match_array(['wds:1030-1DAA-1041']) }
     specify { expect(comparison.conflicts).to be_empty }
@@ -291,6 +323,10 @@ describe MembershipComparison do
       )
     end
 
+    # Statements: 2015-12-03 ------------> 2016-04-03 |
+    # Term:                  2015-12-03 ->            |
+    # Suggestion:                                     | 2017-01-03 ->
+
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to be_empty } # Currently fails
@@ -305,6 +341,10 @@ describe MembershipComparison do
         suggestion: { position: mp, term: term42, start: '2017-01-03', party: liberal, district: pontiac }
       )
     end
+
+    # Statements: 2015-12-03 -------------------------->
+    # Term:                  2015-12-03 --------------->
+    # Suggestion:                          2017-01-03 ->
 
     specify { expect(comparison.exact_matches).to be_empty } # Currently fails
     specify { expect(comparison.partial_matches).to be_empty }

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -342,9 +342,9 @@ describe MembershipComparison do
       )
     end
 
-    # Statements: 2015-12-03 -------------------------->
-    # Term:                  2015-12-03 --------------->
-    # Suggestion:                          2017-01-03 ->
+    # Statements: 2015-12-03 ----------------------->
+    # Term:                  2015-12-03 ------------>
+    # Suggestion:                       2017-01-03 ->
 
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -279,4 +279,20 @@ describe MembershipComparison do
     specify { expect(comparison.partial_matches).to match_array(['wds:1030-1DAA-1041']) }
     specify { expect(comparison.conflicts).to be_empty }
   end
+
+  context 'member returns within term' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-3106' => { position: mp, start: '2015-12-03', end: '2016-04-03', party: liberal,
+                                    district: pontiac, },
+        },
+        suggestion: { position: mp, term: term42, start: '2017-01-03', party: liberal, district: pontiac }
+      )
+    end
+
+    specify { expect(comparison.exact_matches).to be_empty }
+    specify { expect(comparison.partial_matches).to be_empty }
+    specify { expect(comparison.conflicts).to be_empty } # Currently fails
+  end
 end


### PR DESCRIPTION
Given an earlier ceased membership of the same term, a member should be
able to return later.