### PR TITLE
Remove aliased methods

### DIFF
--- a/lib/membership_comparison/field_comparison.rb
+++ b/lib/membership_comparison/field_comparison.rb
@@ -19,9 +19,6 @@ class MembershipComparison
       @suggestion = suggestion
       @a = statement[field]
       @b = suggestion[field]
-
-      self.class.send(:alias_method, "statement_#{field}", :a)
-      self.class.send(:alias_method, "suggestion_#{field}", :b)
     end
 
     def exact?

--- a/lib/membership_comparison/start_comparison.rb
+++ b/lib/membership_comparison/start_comparison.rb
@@ -16,6 +16,10 @@ class MembershipComparison
       statement_end && statement_start < statement_end
     end
 
+    def statement_start
+      statement[:start]
+    end
+
     def statement_end
       statement[:end]
     end


### PR DESCRIPTION
Currently is used in one place so there isn't much point of these. They 
also prevent the method of being overridden in a subclass.