### PR TITLE
Change behaviour of when previous term still open

### DIFF
--- a/lib/membership_comparison/date_helpers.rb
+++ b/lib/membership_comparison/date_helpers.rb
@@ -53,7 +53,7 @@ class MembershipComparison
     end
 
     def statement_open?
-      !statement_closed?
+      statement_start && !statement_closed?
     end
 
     def term_started?
@@ -65,7 +65,7 @@ class MembershipComparison
     end
 
     def term_open?
-      !term_closed?
+      term_start && !term_closed?
     end
 
     def suggestion_started?
@@ -77,7 +77,7 @@ class MembershipComparison
     end
 
     def suggestion_open?
-      !suggestion_closed?
+      suggestion_start && !suggestion_closed?
     end
 
     def statement_start

--- a/lib/membership_comparison/date_helpers.rb
+++ b/lib/membership_comparison/date_helpers.rb
@@ -40,6 +40,12 @@ class MembershipComparison
       statement_start < eopt
     end
 
+    def ended_before_end_of_previous_term?
+      return false unless eopt && statement_closed?
+
+      statement_end <= eopt
+    end
+
     def no_term_or_statement_start?
       !statement_value && !statement_started?
     end

--- a/lib/membership_comparison/date_helpers.rb
+++ b/lib/membership_comparison/date_helpers.rb
@@ -35,7 +35,7 @@ class MembershipComparison
     end
 
     def started_before_end_of_previous_term?
-      return false unless eopt && statement_started?
+      return false unless eopt && statement_open?
 
       statement_start < eopt
     end

--- a/lib/membership_comparison/term_comparison.rb
+++ b/lib/membership_comparison/term_comparison.rb
@@ -24,7 +24,7 @@ class MembershipComparison
     end
 
     def _partial?
-      !(started_before_end_of_previous_term? || suggestion_started_after_statement_ended?) &&
+      !(ended_before_end_of_previous_term? || suggestion_started_after_statement_ended?) &&
         (no_term_or_statement_start? || term_started_during_statement? || term_started_after_statement?)
     end
 

--- a/lib/membership_comparison/term_comparison.rb
+++ b/lib/membership_comparison/term_comparison.rb
@@ -36,7 +36,7 @@ class MembershipComparison
 
     def previous_term_still_open?
       !suggestion_started_after_statement_ended? &&
-        suggestion_started_after_statement_and_term?
+        (suggestion_started_after_statement_and_term? || started_before_end_of_previous_term?)
     end
   end
 end

--- a/lib/membership_comparison/term_comparison.rb
+++ b/lib/membership_comparison/term_comparison.rb
@@ -31,7 +31,7 @@ class MembershipComparison
     def spanning_terms?
       !suggestion_started_after_statement_ended? &&
         term_started_during_statement? &&
-        (statement_open? || term_open? || term_ended_after_statement?)
+        (term_open? || term_ended_after_statement?)
     end
 
     def previous_term_still_open?

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -276,25 +276,6 @@ describe MembershipComparison do
     specify { expect(comparison.problems['wds:1030-1DAA-3104']).to be_empty }
   end
 
-  xcontext 'existing dated P39, started before previous term ended' do
-    let(:comparison) do
-      MembershipComparison.new(
-        existing:   {
-          'wds:1030-1DAA-3104' => { position: mp, start: '2015-03-10', party: liberal, district: pontiac },
-        },
-        suggestion: suggestion
-      )
-    end
-
-    # Statements: 2015-03-10 ------------> |
-    # Term:                  -> 2015-08-02 | 2015-12-03 ->
-
-    specify { expect(comparison.exact_matches).to be_empty }
-    specify { expect(comparison.partial_matches).to be_empty }
-    specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3104']) }
-    specify { expect(comparison.problems['wds:1030-1DAA-3104']).to match_array(['previous term still open']) }
-  end
-
   context 'existing dated P39 spanning terms' do
     let(:comparison) do
       MembershipComparison.new(
@@ -464,6 +445,25 @@ describe MembershipComparison do
     specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3107']) }
     specify { expect(comparison.problems['wds:1030-1DAA-3107']).to match_array(['previous term still open']) }
+  end
+
+  xcontext 'existing dated P39, started before previous term ended' do
+    let(:comparison) do
+      MembershipComparison.new(
+        existing:   {
+          'wds:1030-1DAA-3104' => { position: mp, start: '2015-03-10', party: liberal, district: pontiac },
+        },
+        suggestion: suggestion
+      )
+    end
+
+    # Statements: 2015-03-10 ------------> |
+    # Term:                  -> 2015-08-02 | 2015-12-03 ->
+
+    specify { expect(comparison.exact_matches).to be_empty }
+    specify { expect(comparison.partial_matches).to be_empty }
+    specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3104']) }
+    specify { expect(comparison.problems['wds:1030-1DAA-3104']).to match_array(['previous term still open']) }
   end
 
   context 'existing statement, started during a term' do

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -290,7 +290,7 @@ describe MembershipComparison do
     # Term:                  -> 2015-08-02 | 2015-12-03 ->
 
     specify { expect(comparison.exact_matches).to be_empty }
-    specify { expect(comparison.partial_matches).to be_empty } # Currently fails
+    specify { expect(comparison.partial_matches).to be_empty }
     specify { expect(comparison.conflicts).to be_empty }
     specify { expect(comparison.problems['wds:1030-1DAA-3104']).to be_empty }
   end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -276,7 +276,7 @@ describe MembershipComparison do
     specify { expect(comparison.problems['wds:1030-1DAA-3104']).to be_empty }
   end
 
-  context 'existing dated P39, started before previous term ended' do
+  xcontext 'existing dated P39, started before previous term ended' do
     let(:comparison) do
       MembershipComparison.new(
         existing:   {
@@ -291,8 +291,8 @@ describe MembershipComparison do
 
     specify { expect(comparison.exact_matches).to be_empty }
     specify { expect(comparison.partial_matches).to be_empty }
-    specify { expect(comparison.conflicts).to be_empty }
-    specify { expect(comparison.problems['wds:1030-1DAA-3104']).to be_empty }
+    specify { expect(comparison.conflicts).to match_array(['wds:1030-1DAA-3104']) }
+    specify { expect(comparison.problems['wds:1030-1DAA-3104']).to match_array(['previous term still open']) }
   end
 
   context 'existing dated P39 spanning terms' do

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -447,7 +447,7 @@ describe MembershipComparison do
     specify { expect(comparison.problems['wds:1030-1DAA-3107']).to match_array(['previous term still open']) }
   end
 
-  xcontext 'existing dated P39, started before previous term ended' do
+  context 'existing dated P39, started before previous term ended' do
     let(:comparison) do
       MembershipComparison.new(
         existing:   {


### PR DESCRIPTION
Change `existing dated P39, started before previous term ended` behaviour to be a conflict rather than allowing us to create new P39s without closing the previous one.