### PR TITLE
Support superclass positions

### DIFF
--- a/lib/membership_comparison.rb
+++ b/lib/membership_comparison.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative './membership_comparison/statement_comparison'
+require_relative './membership_comparison/position_comparison'
 
 class MembershipComparison
   def initialize(existing:, suggestion:)
@@ -48,7 +48,7 @@ class MembershipComparison
 
   def comparisons
     @comparisons ||= existing.each_with_object({}) do |(id, statement), memo|
-      memo[id] = StatementComparison.new(
+      memo[id] = PositionComparison.new(
         statement:  statement,
         suggestion: suggestion,
         options:    options

--- a/lib/membership_comparison/position_comparison.rb
+++ b/lib/membership_comparison/position_comparison.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative './statement_comparison'
+
+class MembershipComparison
+  class PositionComparison < StatementComparison
+    alias statement_state state
+
+    def state
+      return unless position_match? || superclass_match?
+      return :ignore if bare?
+      return :conflict if conflicted?
+
+      super
+    end
+
+    def conflicts
+      return [] unless position_match? || superclass_match?
+      return ['position conflict'] if conflicted? && !bare?
+
+      super
+    end
+
+    def field_states
+      return {} unless position_match? || superclass_match?
+
+      super.tap do |states|
+        states[:position] = state if superclass_match?
+      end
+    end
+
+    private
+
+    def position_match?
+      statement[:position] == suggestion[:position]
+    end
+
+    def superclass_match?
+      statement[:position] == suggestion[:position_parent]
+    end
+
+    def bare?
+      superclass_match? && statement.reject { |k| k == :position }.values.all?(&:empty?)
+    end
+
+    def conflicted?
+      # Exact and Partial states should be considered as conflicts when we're
+      # comparing superclass positions as we don't support updating these.
+
+      superclass_match? && %i[exact partial].include?(statement_state)
+    end
+  end
+end

--- a/lib/membership_comparison/statement_comparison.rb
+++ b/lib/membership_comparison/statement_comparison.rb
@@ -14,8 +14,6 @@ class MembershipComparison
     end
 
     def state
-      return unless statement[:position] == suggestion[:position]
-
       if comparisons.all?(&:exact?)
         :exact
       elsif comparisons.any?(&:ignore?)

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -335,7 +335,7 @@ describe MembershipComparison do
     let(:greens) { { id: 'Q9669' } }
     let(:brighton) { { id: 'Q1070099' } }
 
-    xcontext 'when the statement is bare' do
+    context 'when the statement is bare' do
       subject(:suggestion) do
         { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
       end
@@ -346,7 +346,7 @@ describe MembershipComparison do
       specify { expect(statement).to be_ignored }
     end
 
-    xcontext 'when suggesting the same data' do
+    context 'when suggesting the same data' do
       subject(:suggestion) do
         { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
       end
@@ -357,7 +357,7 @@ describe MembershipComparison do
       specify { expect(statement).to be_a_conflict.with_problem('position conflict') }
     end
 
-    xcontext 'when suggesting additional data' do
+    context 'when suggesting additional data' do
       subject(:suggestion) do
         { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
       end
@@ -368,7 +368,7 @@ describe MembershipComparison do
       specify { expect(statement).to be_a_conflict.with_problem('position conflict') }
     end
 
-    xcontext 'when suggestion new data' do
+    context 'when suggestion new data' do
       subject(:suggestion) do
         { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
       end

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -322,4 +322,61 @@ describe MembershipComparison do
     it { is_expected.not_to be_actionable }
     specify { expect(statement).to be_a_conflict.with_problem('district is a disambiguation') }
   end
+
+  context 'when there are existing statements for a superclass position' do
+    let(:subclass) { term_specific_mp }
+    let(:superclass) { mp }
+
+    let(:mp) { { id: 'Q16707842' } } # Member of Parliament of the United Kingdom
+    let(:term_specific_mp) { { id: 'Q30524710' } } # Member of the 57th Parliament of the United Kingdom
+
+    let(:term56) { { id: 'Q21084473' } }
+    let(:term57) { { id: 'Q29974940' } }
+    let(:greens) { { id: 'Q9669' } }
+    let(:brighton) { { id: 'Q1070099' } }
+
+    xcontext 'when the statement is bare' do
+      subject(:suggestion) do
+        { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
+      end
+
+      let(:statement) { { position: superclass, term: {} } }
+
+      it { is_expected.to be_actionable }
+      specify { expect(statement).to be_ignored }
+    end
+
+    xcontext 'when suggesting the same data' do
+      subject(:suggestion) do
+        { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
+      end
+
+      let(:statement) { { position: superclass, term: term57, party: greens, district: brighton } }
+
+      it { is_expected.not_to be_actionable }
+      specify { expect(statement).to be_a_conflict.with_problem('position conflict') }
+    end
+
+    xcontext 'when suggesting additional data' do
+      subject(:suggestion) do
+        { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
+      end
+
+      let(:statement) { { position: superclass, party: greens } }
+
+      it { is_expected.not_to be_actionable }
+      specify { expect(statement).to be_a_conflict.with_problem('position conflict') }
+    end
+
+    xcontext 'when suggestion new data' do
+      subject(:suggestion) do
+        { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
+      end
+
+      let(:statement) { { position: superclass, term: term56, party: greens, district: brighton } }
+
+      it { is_expected.to be_actionable }
+      specify { expect(statement).to be_ignored }
+    end
+  end
 end


### PR DESCRIPTION
Extracted from #25 
Requires #27 
Required for mysociety/verification-pages#314

Need to pass in the `position_parent` with the suggestion for this to work.