### PR TITLE
Fix issue checking when statements are bare

### DIFF
--- a/lib/membership_comparison/position_comparison.rb
+++ b/lib/membership_comparison/position_comparison.rb
@@ -44,7 +44,9 @@ class MembershipComparison
     end
 
     def bare?
-      (superclass_match? || subclass_match?) && statement.reject { |k| k == :position }.values.all?(&:empty?)
+      (superclass_match? || subclass_match?) && statement.reject { |k| k == :position }.values.all? do |value|
+        value.nil? || value.empty?
+      end
     end
 
     def conflicted?

--- a/spec/membership_comparison_spec.rb
+++ b/spec/membership_comparison_spec.rb
@@ -340,7 +340,7 @@ describe MembershipComparison do
         { position: subclass, position_parent: superclass, term: term57, party: greens, district: brighton }
       end
 
-      let(:statement) { { position: superclass, term: {} } }
+      let(:statement) { { position: superclass, start: nil, end: nil, term: {} } }
 
       it { is_expected.to be_actionable }
       specify { expect(statement).to be_ignored }
@@ -397,7 +397,7 @@ describe MembershipComparison do
         { position: superclass, position_children: [subclass], term: term57, party: greens, district: brighton }
       end
 
-      let(:statement) { { position: subclass, term: {} } }
+      let(:statement) { { position: subclass, start: nil, end: nil, term: {} } }
 
       it { is_expected.to be_actionable }
       specify { expect(statement).to be_ignored }


### PR DESCRIPTION
Fixes #31 

If a statement was matches superclass or subclass with nil values an
exception would be raised as NilClass doesn't respond to #empty?.